### PR TITLE
Remove json-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
  - Support both Laravel PHP and JSON translation files.
  - 100% test coverage.
- - Only has two dependencies: [json-loader](https://github.com/webpack-contrib/json-loader) and [php-array-loader](https://github.com/rmariuzzo/php-array-loader).
+ - Only has one dependencies: [php-array-loader](https://github.com/rmariuzzo/php-array-loader).
 
 ## Installation
 
@@ -47,7 +47,7 @@ mix.webpackConfig({
     rules: [
       {
         // Matches all PHP or JSON files in `resources/lang` directory.
-        test: /resources[\\\/]lang.+\.(php|json)$/,
+        test: /resources[\\\/]lang.+\.(php)$/,
         loader: 'laravel-localization-loader',
       }
     ]
@@ -66,9 +66,9 @@ First, you will need to install [Lang.js](https://github.com/rmariuzzo/Lang.js) 
 export default {
   // The key format should be: 'locale.filename'.
   'en.messages': require('../../resources/lang/en/messages.php'),
-  'es.messages': require('../../resources/lang/es/messages.php'),
+  'es': require('../../resources/lang/es.json'),
   'en.auth': require('../../resources/lang/en/auth.php'),
-  'es.auth': require('../../resources/lang/es/auth.php'),
+  'en': require('../../resources/lang/en.json'),
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
  */
 
 var phpArrayLoader = require('php-array-loader')
-var jsonLoader = require('json-loader')
 
 /**
  * Module exports.
@@ -21,11 +20,5 @@ module.exports = laravelLocalizationLoader
  */
 
 function laravelLocalizationLoader(source) {
-  var isPHP = ~source.indexOf('<?php')
-
-  if (isPHP) {
     return phpArrayLoader(source)
-  } else {
-    return jsonLoader(source)
-  }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "webpack-merge": "^4.0.0"
   },
   "dependencies": {
-    "json-loader": "^0.5.4",
     "php-array-loader": "^1.0.0"
   }
 }

--- a/tests/loader.test.js
+++ b/tests/loader.test.js
@@ -77,7 +77,7 @@ function runWebpack(outputDir, config) {
       module: {
         rules: [
           {
-            test: /resources[\\\/]lang.+\.(php|json)$/,
+            test: /resources[\\\/]lang.+\.(php)$/,
             loader: 'laravel-localization-loader',
           }
         ]


### PR DESCRIPTION
As of Webpack supports json natively from version 2 on we can remove this dependency completely and I think we can also drop support for webpack older than v2...

**Tests fail because of: https://github.com/rmariuzzo/laravel-localization-loader/pull/11**

Will fix https://github.com/rmariuzzo/laravel-localization-loader/issues/9 and https://github.com/rmariuzzo/laravel-localization-loader/issues/8