### PR TITLE
add test url

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  "testURL": "http://localhost",
   "verbose": true,
   "notify": false,
   "modulePathIgnorePatterns": ["<rootDir>/tests/output/"],


### PR DESCRIPTION
seems `testUrl` in newer jest version: https://github.com/facebook/jest/issues/6766 https://github.com/jsdom/jsdom/issues/2304